### PR TITLE
fix addmarker race condition

### DIFF
--- a/app/src/runningroutes/static/frontend/runningroute-route.js
+++ b/app/src/runningroutes/static/frontend/runningroute-route.js
@@ -138,6 +138,10 @@ SVGOverlay.prototype.onAdd = function () {
     this.map.addListener('idle', this.onIdle);
     this.map.addListener('bounds_changed', this.onPanZoom);
     this.onPanZoom();
+    // nothing to do if data hasn't loaded yet
+    if (!this.data?.length) return;
+    this.addmarkers();
+    this.draw();
 };
 
 SVGOverlay.prototype.fitbounds = function ( ) {
@@ -160,6 +164,9 @@ SVGOverlay.prototype.setdata = function ( data ) {
 
     // change bounds depending on data
     this.fitbounds();
+
+    // nothing to do if onAdd hasn't been called yet
+    if (!this.svg) return;
 
     // create start, finish and mile icons
     this.addmarkers();


### PR DESCRIPTION
Sometimes the markers fail to load on a route view. This happens when the data loads before the map has loaded and `this.svg` is null. 

Steps to reproduce: visit https://www.routes.loutilities.com/route/146, open dev tools -> disable cache -> refresh a few times.

<img width="821" height="580" alt="race-condition" src="https://github.com/user-attachments/assets/38acb46e-492b-474c-8f63-1da334f0552a" />
