### PR TITLE
add .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,12 @@
+ACCESS_LOG=/tmp/access.log
+APP_DATABASE=routes
+APP_FILE_FOLDER_HOST=./config/files
+APP_LOGGING_HOST=/tmp/logs
+APP_LOGGING_PATH=/tmp/logs
+APP_NAME=runningroutes
+APP_VER=latest
+DB_INIT_DIR=./app/src/app-initdb.d
+FLASK_APP_FILE_FOLDER=/tmp/files
+MYSQL_VER=8.0.40
+PYTHON_VER=3.11
+VAR_LOG_HOST=/var/log

--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,7 @@ APP_LOGGING_HOST=/tmp/logs
 APP_LOGGING_PATH=/tmp/logs
 APP_NAME=runningroutes
 APP_VER=latest
+COMPOSE_FILE="docker-compose.yml;docker-compose.dev.yml"
 DB_INIT_DIR=./app/src/app-initdb.d
 FLASK_APP_FILE_FOLDER=/tmp/files
 MYSQL_VER=8.0.40

--- a/.env.sample
+++ b/.env.sample
@@ -8,5 +8,5 @@ APP_VER=latest
 DB_INIT_DIR=./app/src/app-initdb.d
 FLASK_APP_FILE_FOLDER=/tmp/files
 MYSQL_VER=8.0.40
-PYTHON_VER=3.11
+PYTHON_VER=3.12
 VAR_LOG_HOST=/var/log


### PR DESCRIPTION
This is the minimal set of environment variables I needed in .env to `docker-compose up app --build`. We can add to the development instructions to `cp .env.sample .env`

I chose `/tmp` for logs but `config/files` for uploads because it's already a volume 
https://github.com/louking/runningroutes/blob/415c5cc922ce8b252e8a811df4ad361199ef528f/docker-compose.yml#L78-L79
(gpx uploads should persist in a development environment) but happy to change these if there's a preferred directory for these kinds of things. 